### PR TITLE
fix download file, closes #12

### DIFF
--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDLUpdater.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDLUpdater.java
@@ -107,7 +107,11 @@ public class YoutubeDLUpdater {
             file = File.createTempFile("youtube_dl", "zip", application.getCacheDir());
             out = new FileOutputStream(file);
             outChannel = out.getChannel();
-            outChannel.transferFrom(inChannel, 0, Long.MAX_VALUE);
+            long bytesRead=0;
+            long transferPosition=0;
+            while ((bytesRead=outChannel.transferFrom(inChannel,transferPosition,1 << 24)) > 0) {
+                transferPosition+=bytesRead;
+            }
         } catch (Exception e) {
             // delete temp file if something went wrong
             if (null != file && file.exists()) {


### PR DESCRIPTION
fixes #12 
related
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=5105464
https://stackoverflow.com/questions/28088408/filechannel-transferfrom-fails-for-larger-files-with-out-of-memory-error