### PR TITLE
Add fields in VideoInfo and VideoFormat

### DIFF
--- a/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoFormat.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoFormat.java
@@ -23,6 +23,8 @@ public class VideoFormat {
     private int width;
     private int height;
     private long filesize;
+    @JsonProperty("filesize_approx")
+    private long fileSizeApproximate;
     private int fps;
     private String url;
     @JsonProperty("manifest_url")
@@ -80,6 +82,10 @@ public class VideoFormat {
 
     public long getFilesize() {
         return filesize;
+    }
+
+    public long getFileSizeApproximate() {
+        return fileSizeApproximate;
     }
 
     public int getFps() {

--- a/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoFormat.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoFormat.java
@@ -22,7 +22,8 @@ public class VideoFormat {
     private String acodec;
     private int width;
     private int height;
-    private long filesize;
+    @JsonProperty("filesize")
+    private long fileSize;
     @JsonProperty("filesize_approx")
     private long fileSizeApproximate;
     private int fps;
@@ -80,8 +81,8 @@ public class VideoFormat {
         return height;
     }
 
-    public long getFilesize() {
-        return filesize;
+    public long getFileSize() {
+        return fileSize;
     }
 
     public long getFileSizeApproximate() {

--- a/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoInfo.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoInfo.java
@@ -21,6 +21,10 @@ public class VideoInfo {
     private String thumbnail;
     private String license;
 
+    private String extractor;
+    @JsonProperty("extractor_key")
+    private String extractorKey;
+
     @JsonProperty("view_count")
     private String viewCount;
     @JsonProperty("like_count")
@@ -51,6 +55,9 @@ public class VideoInfo {
     @JsonProperty("format_id")
     private String formatId;
     private String ext;
+    private long filesize;
+    @JsonProperty("filesize_approx")
+    private long fileSizeApproximate;
 
     @JsonProperty("http_headers")
     private Map<String, String> httpHeaders;
@@ -165,6 +172,14 @@ public class VideoInfo {
         return ext;
     }
 
+    public long getFilesize() {
+        return filesize;
+    }
+
+    public long getFileSizeApproximate() {
+        return fileSizeApproximate;
+    }
+
     public Map<String, String> getHttpHeaders() {
         return httpHeaders;
     }
@@ -195,5 +210,13 @@ public class VideoInfo {
 
     public String getUrl() {
         return url;
+    }
+
+    public String getExtractorKey() {
+        return extractorKey;
+    }
+
+    public String getExtractor() {
+        return extractor;
     }
 }

--- a/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoInfo.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoInfo.java
@@ -55,7 +55,8 @@ public class VideoInfo {
     @JsonProperty("format_id")
     private String formatId;
     private String ext;
-    private long filesize;
+    @JsonProperty("filesize")
+    private long fileSize;
     @JsonProperty("filesize_approx")
     private long fileSizeApproximate;
 
@@ -172,8 +173,8 @@ public class VideoInfo {
         return ext;
     }
 
-    public long getFilesize() {
-        return filesize;
+    public long getFileSize() {
+        return fileSize;
     }
 
     public long getFileSizeApproximate() {

--- a/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoInfo.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/mapper/VideoInfo.java
@@ -20,11 +20,9 @@ public class VideoInfo {
     private String description;
     private String thumbnail;
     private String license;
-
     private String extractor;
     @JsonProperty("extractor_key")
     private String extractorKey;
-
     @JsonProperty("view_count")
     private String viewCount;
     @JsonProperty("like_count")
@@ -35,19 +33,15 @@ public class VideoInfo {
     private String repostCount;
     @JsonProperty("average_rating")
     private String averageRating;
-
-
     @JsonProperty("uploader_id")
     private String uploaderId;
     private String uploader;
-
     @JsonProperty("player_url")
     private String playerUrl;
     @JsonProperty("webpage_url")
     private String webpageUrl;
     @JsonProperty("webpage_url_basename")
     private String webpageUrlBasename;
-
     private String resolution;
     private int width;
     private int height;
@@ -59,7 +53,6 @@ public class VideoInfo {
     private long fileSize;
     @JsonProperty("filesize_approx")
     private long fileSizeApproximate;
-
     @JsonProperty("http_headers")
     private Map<String, String> httpHeaders;
     private ArrayList<String> categories;
@@ -213,11 +206,11 @@ public class VideoInfo {
         return url;
     }
 
-    public String getExtractorKey() {
-        return extractorKey;
-    }
-
     public String getExtractor() {
         return extractor;
+    }
+
+    public String getExtractorKey() {
+        return extractorKey;
     }
 }


### PR DESCRIPTION
`filesize` often seems to be null so it would be useful to have `filesize_approx` available.
`extractor` or `extractor_key` could be used in tagging video by website it's downloaded from.