### PR TITLE
Possible fix for Seal issues with Termux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ ext {
     // supports java 1.6
     commonsIoVer = '2.5'
     // supports java 1.6
-    commonsCompressVer = '1.20'
+    commonsCompressVer = '1.12'
     coreKtxVer = '1.8.0'
 }
 

--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
@@ -23,6 +23,7 @@ object YoutubeDL {
     private var ENV_LD_LIBRARY_PATH: String? = null
     private var ENV_SSL_CERT_FILE: String? = null
     private var ENV_PYTHONHOME: String? = null
+    private var HOME: String? = null
     private val idProcessMap = Collections.synchronizedMap(HashMap<String, Process>())
 
     @Synchronized
@@ -45,6 +46,7 @@ object YoutubeDL {
                 aria2cDir.absolutePath + "/usr/lib"
         ENV_SSL_CERT_FILE = pythonDir.absolutePath + "/usr/etc/tls/cert.pem"
         ENV_PYTHONHOME = pythonDir.absolutePath + "/usr"
+        HOME = appContext.filesDir.absolutePath
         initPython(appContext, pythonDir)
         init_ytdlp(appContext, ytdlpDir)
         initialized = true
@@ -168,6 +170,7 @@ object YoutubeDL {
             this["SSL_CERT_FILE"] = ENV_SSL_CERT_FILE
             this["PATH"] = System.getenv("PATH") + ":" + binDir!!.absolutePath
             this["PYTHONHOME"] = ENV_PYTHONHOME
+            this["HOME"] = HOME
         }
         process = try {
             processBuilder.start()


### PR DESCRIPTION
yt-dlp seems to take the termux internal files path as HOME (Linux principal directory). Adding the appContext.filesDir provided by  the app that is using youtubedl-android as HOME, we force the python enviroment to take that variable as main directory and not Termux one.