### PR TITLE
Allow update from nightly or stable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ try {
 
 * yt-dlp supports myriad different options which be seen [here](https://github.com/yt-dlp/yt-dlp)
 
-* yt-dlp binary can be updated from within the library
+* yt-dlp binary can be updated from within the library (A example can be found in the [sample app](app/src/main/java/com/yausername/youtubedl_android_example/MainActivity.java))
 ```java
-    YoutubeDL.getInstance().updateYoutubeDL(this);
+    YoutubeDL.getInstance().updateYoutubeDL(this, updateChannel); // UpdateChannel.NIGHTLY or UpdateChannel.STABLE
 ```
 
 ## FFmpeg

--- a/app/src/main/java/com/yausername/youtubedl_android_example/MainActivity.java
+++ b/app/src/main/java/com/yausername/youtubedl_android_example/MainActivity.java
@@ -1,5 +1,7 @@
 package com.yausername.youtubedl_android_example;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -81,13 +83,22 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 break;
             }
             case R.id.btn_update: {
-                updateYoutubeDL();
+                AlertDialog dialog = new AlertDialog.Builder(this)
+                        .setTitle("Update Channel")
+                        .setItems(new String[] {"Stable Releases", "Nightly Releases"}, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int which) {
+                                updateYoutubeDL(which == 0 ? YoutubeDL.UpdateChannel.STABLE : YoutubeDL.UpdateChannel.NIGHTLY);
+                            }
+                        })
+                        .create();
+                dialog.show();
                 break;
             }
         }
     }
 
-    private void updateYoutubeDL() {
+    private void updateYoutubeDL(YoutubeDL.UpdateChannel updateChannel) {
         if (updating) {
             Toast.makeText(MainActivity.this, "update is already in progress", Toast.LENGTH_LONG).show();
             return;
@@ -95,17 +106,17 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
         updating = true;
         progressBar.setVisibility(View.VISIBLE);
-        Disposable disposable = Observable.fromCallable(() -> YoutubeDL.getInstance().updateYoutubeDL(getApplication()))
+        Disposable disposable = Observable.fromCallable(() -> YoutubeDL.getInstance().updateYoutubeDL(getApplication(), updateChannel))
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(status -> {
                     progressBar.setVisibility(View.GONE);
                     switch (status) {
                         case DONE:
-                            Toast.makeText(MainActivity.this, "update successful", Toast.LENGTH_LONG).show();
+                            Toast.makeText(MainActivity.this, "update successful: " + YoutubeDL.getInstance().version(getApplication()), Toast.LENGTH_LONG).show();
                             break;
                         case ALREADY_UP_TO_DATE:
-                            Toast.makeText(MainActivity.this, "already up to date", Toast.LENGTH_LONG).show();
+                            Toast.makeText(MainActivity.this, "already up to date: " + YoutubeDL.getInstance().version(getApplication()), Toast.LENGTH_LONG).show();
                             break;
                         default:
                             Toast.makeText(MainActivity.this, status.toString(), Toast.LENGTH_LONG).show();

--- a/app/src/main/java/com/yausername/youtubedl_android_example/MainActivity.java
+++ b/app/src/main/java/com/yausername/youtubedl_android_example/MainActivity.java
@@ -1,7 +1,6 @@
 package com.yausername.youtubedl_android_example;
 
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
@@ -30,7 +29,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private ProgressBar progressBar;
 
     private boolean updating = false;
-    private CompositeDisposable compositeDisposable = new CompositeDisposable();
+    private final CompositeDisposable compositeDisposable = new CompositeDisposable();
 
     private static final String TAG = "MainActivity";
 
@@ -85,12 +84,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
             case R.id.btn_update: {
                 AlertDialog dialog = new AlertDialog.Builder(this)
                         .setTitle("Update Channel")
-                        .setItems(new String[] {"Stable Releases", "Nightly Releases"}, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialogInterface, int which) {
-                                updateYoutubeDL(which == 0 ? YoutubeDL.UpdateChannel.STABLE : YoutubeDL.UpdateChannel.NIGHTLY);
-                            }
-                        })
+                        .setItems(new String[]{"Stable Releases", "Nightly Releases"},
+                                (dialogInterface, which) -> updateYoutubeDL(which == 0
+                                        ? YoutubeDL.UpdateChannel.STABLE : YoutubeDL.UpdateChannel.NIGHTLY))
                         .create();
                 dialog.show();
                 break;
@@ -100,23 +96,23 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     private void updateYoutubeDL(YoutubeDL.UpdateChannel updateChannel) {
         if (updating) {
-            Toast.makeText(MainActivity.this, "update is already in progress", Toast.LENGTH_LONG).show();
+            Toast.makeText(MainActivity.this, "Update is already in progress!", Toast.LENGTH_LONG).show();
             return;
         }
 
         updating = true;
         progressBar.setVisibility(View.VISIBLE);
-        Disposable disposable = Observable.fromCallable(() -> YoutubeDL.getInstance().updateYoutubeDL(getApplication(), updateChannel))
+        Disposable disposable = Observable.fromCallable(() -> YoutubeDL.getInstance().updateYoutubeDL(this, updateChannel))
                 .subscribeOn(Schedulers.newThread())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(status -> {
                     progressBar.setVisibility(View.GONE);
                     switch (status) {
                         case DONE:
-                            Toast.makeText(MainActivity.this, "update successful: " + YoutubeDL.getInstance().version(getApplication()), Toast.LENGTH_LONG).show();
+                            Toast.makeText(MainActivity.this, "Update successful " + YoutubeDL.getInstance().versionName(this), Toast.LENGTH_LONG).show();
                             break;
                         case ALREADY_UP_TO_DATE:
-                            Toast.makeText(MainActivity.this, "already up to date: " + YoutubeDL.getInstance().version(getApplication()), Toast.LENGTH_LONG).show();
+                            Toast.makeText(MainActivity.this, "Already up to date " + YoutubeDL.getInstance().versionName(this), Toast.LENGTH_LONG).show();
                             break;
                         default:
                             Toast.makeText(MainActivity.this, status.toString(), Toast.LENGTH_LONG).show();
@@ -124,7 +120,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                     }
                     updating = false;
                 }, e -> {
-                    if(BuildConfig.DEBUG) Log.e(TAG, "failed to update", e);
+                    if (BuildConfig.DEBUG) Log.e(TAG, "failed to update", e);
                     progressBar.setVisibility(View.GONE);
                     Toast.makeText(MainActivity.this, "update failed", Toast.LENGTH_LONG).show();
                     updating = false;

--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.java
@@ -266,10 +266,10 @@ public class YoutubeDL {
         return youtubeDLResponse;
     }
 
-    synchronized public UpdateStatus updateYoutubeDL(Context appContext) throws YoutubeDLException {
+    synchronized public UpdateStatus updateYoutubeDL(Context appContext, UpdateChannel updateChannel) throws YoutubeDLException {
         assertInit();
         try {
-            return YoutubeDLUpdater.update(appContext);
+            return YoutubeDLUpdater.update(appContext, updateChannel);
         } catch (IOException e) {
             throw new YoutubeDLException("failed to update youtube-dl", e);
         }
@@ -282,5 +282,9 @@ public class YoutubeDL {
 
     public enum UpdateStatus {
         DONE, ALREADY_UP_TO_DATE
+    }
+
+    public enum UpdateChannel {
+        STABLE, NIGHTLY
     }
 }

--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.java
@@ -280,6 +280,11 @@ public class YoutubeDL {
         return YoutubeDLUpdater.version(appContext);
     }
 
+    @Nullable
+    public String versionName(Context appContext) {
+        return YoutubeDLUpdater.versionName(appContext);
+    }
+
     public enum UpdateStatus {
         DONE, ALREADY_UP_TO_DATE
     }

--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDLUpdater.java
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDLUpdater.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.yausername.youtubedl_android.YoutubeDL.UpdateStatus;
+import com.yausername.youtubedl_android.YoutubeDL.UpdateChannel;
 import com.yausername.youtubedl_common.SharedPrefsHelper;
 
 import org.apache.commons.io.FileUtils;
@@ -21,11 +22,12 @@ class YoutubeDLUpdater {
     private YoutubeDLUpdater() {
     }
 
-    private static final String releasesUrl = "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest";
+    private static final String youtubeDLStableChannelUrl = "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest";
+    private static final String youtubeDLNightlyChannelUrl = "https://api.github.com/repos/yt-dlp/yt-dlp-nightly-builds/releases/latest";
     private static final String youtubeDLVersionKey = "youtubeDLVersion";
 
-    static UpdateStatus update(Context appContext) throws IOException, YoutubeDLException {
-        JsonNode json = checkForUpdate(appContext);
+    static UpdateStatus update(Context appContext, UpdateChannel youtubeDLChannel) throws IOException, YoutubeDLException {
+        JsonNode json = checkForUpdate(appContext, youtubeDLChannel);
         if (null == json) return UpdateStatus.ALREADY_UP_TO_DATE;
 
         String downloadUrl = getDownloadUrl(json);
@@ -57,8 +59,8 @@ class YoutubeDLUpdater {
         SharedPrefsHelper.update(appContext, youtubeDLVersionKey, tag);
     }
 
-    private static JsonNode checkForUpdate(Context appContext) throws IOException {
-        URL url = new URL(releasesUrl);
+    private static JsonNode checkForUpdate(Context appContext, UpdateChannel youtubeDLChannel) throws IOException {
+        URL url = new URL((youtubeDLChannel == UpdateChannel.NIGHTLY) ? youtubeDLNightlyChannelUrl : youtubeDLStableChannelUrl);
         JsonNode json = YoutubeDL.objectMapper.readTree(url);
         String newVersion = getTag(json);
         String oldVersion = SharedPrefsHelper.get(appContext, youtubeDLVersionKey);
@@ -69,7 +71,7 @@ class YoutubeDLUpdater {
     }
 
     private static String getTag(JsonNode json) {
-        return json.get("tag_name").asText();
+        return json.get("name").asText();
     }
 
     @NonNull


### PR DESCRIPTION
Sometimes, you want to run the nightly build. This adds the ability to switch channels and a dialog in the example.