### PR TITLE
Open the `UpdateChannel` class so that an arbitrary URL can be used

### DIFF
--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
@@ -238,7 +238,7 @@ object YoutubeDL {
         DONE, ALREADY_UP_TO_DATE
     }
 
-    sealed class UpdateChannel(val apiUrl: String) {
+    open class UpdateChannel(val apiUrl: String) {
         object STABLE : UpdateChannel("https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest")
         object NIGHTLY :
             UpdateChannel("https://api.github.com/repos/yt-dlp/yt-dlp-nightly-builds/releases/latest")


### PR DESCRIPTION
Hello,

I want the ability to use a fork of yt-dlp, but right now that is not possible. If we open the `UpdateChannel` class then I can instantiate it with an arbitrary URL and it becomes possible. I can now also use an arbitrary past version if I want to.

I hope this is a welcome change. If there is another way to do it then please let me know.

Thank you! :)
