### PR TITLE
Add option to include ffmpeg progress in output stream

### DIFF
--- a/library/src/main/java/com/yausername/youtubedl_android/StreamProcessExtractor.kt
+++ b/library/src/main/java/com/yausername/youtubedl_android/StreamProcessExtractor.kt
@@ -16,6 +16,7 @@ internal class StreamProcessExtractor(
     private val p = Pattern.compile("\\[download\\]\\s+(\\d+\\.\\d)% .* ETA (\\d+):(\\d+)")
     private val pAria2c =
         Pattern.compile("\\[#\\w{6}.*\\((\\d*\\.*\\d+)%\\).*?((\\d+)m)*((\\d+)s)*]")
+    private val pFFmpeg = Pattern.compile("size=.*")
     private var progress = PERCENT
     private var eta = ETA
 
@@ -49,11 +50,20 @@ internal class StreamProcessExtractor(
 
     private fun getProgress(line: String): Float {
         val matcher = p.matcher(line)
-        if (matcher.find()) return matcher.group(GROUP_PERCENT).toFloat()
-            .also { progress = it } else {
-            val mAria2c = pAria2c.matcher(line)
-            if (mAria2c.find()) return mAria2c.group(1).toFloat().also { progress = it }
+        if (matcher.find()) {
+            return matcher.group(GROUP_PERCENT)!!.toFloat().also { progress = it }
         }
+
+        val mAria2c = pAria2c.matcher(line)
+        if (mAria2c.find()) {
+            return mAria2c.group(1)!!.toFloat().also { progress = it }
+        }
+
+        val mFFmpeg = pFFmpeg.matcher(line)
+        if (mFFmpeg.find()) {
+            return 99f.also { progress = it }
+        }
+
         return progress
     }
 

--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
@@ -158,7 +158,7 @@ object YoutubeDL {
         processId: String? = null,
         callback: ((Float, Long, String) -> Unit)? = null
     ): YoutubeDLResponse {
-        return executeImpl(request, processId, callback, false)
+        return executeImpl(request, processId, false, callback)
     }
 
     @JvmOverloads
@@ -166,18 +166,18 @@ object YoutubeDL {
     fun execute(
         request: YoutubeDLRequest,
         processId: String? = null,
-        callback: ((Float, Long, String) -> Unit)? = null,
-        redirectErrorStream: Boolean
+        redirectErrorStream: Boolean,
+        callback: ((Float, Long, String) -> Unit)? = null
     ): YoutubeDLResponse {
-        return executeImpl(request, processId, callback, redirectErrorStream)
+        return executeImpl(request, processId, redirectErrorStream, callback)
     }
 
     @Throws(YoutubeDLException::class, InterruptedException::class, CanceledException::class)
     private fun executeImpl(
         request: YoutubeDLRequest,
         processId: String? = null,
-        callback: ((Float, Long, String) -> Unit)? = null,
-        redirectErrorStream: Boolean = false
+        redirectErrorStream: Boolean = false,
+        callback: ((Float, Long, String) -> Unit)? = null
     ) : YoutubeDLResponse {
         assertInit()
         if (processId != null && idProcessMap.containsKey(processId)) throw YoutubeDLException("Process ID already exists")

--- a/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
+++ b/library/src/main/java/com/yausername/youtubedl_android/YoutubeDL.kt
@@ -156,9 +156,29 @@ object YoutubeDL {
     fun execute(
         request: YoutubeDLRequest,
         processId: String? = null,
+        callback: ((Float, Long, String) -> Unit)? = null
+    ): YoutubeDLResponse {
+        return executeImpl(request, processId, callback, false)
+    }
+
+    @JvmOverloads
+    @Throws(YoutubeDLException::class, InterruptedException::class, CanceledException::class)
+    fun execute(
+        request: YoutubeDLRequest,
+        processId: String? = null,
+        callback: ((Float, Long, String) -> Unit)? = null,
+        redirectErrorStream: Boolean
+    ): YoutubeDLResponse {
+        return executeImpl(request, processId, callback, redirectErrorStream)
+    }
+
+    @Throws(YoutubeDLException::class, InterruptedException::class, CanceledException::class)
+    private fun executeImpl(
+        request: YoutubeDLRequest,
+        processId: String? = null,
         callback: ((Float, Long, String) -> Unit)? = null,
         redirectErrorStream: Boolean = false
-    ): YoutubeDLResponse {
+    ) : YoutubeDLResponse {
         assertInit()
         if (processId != null && idProcessMap.containsKey(processId)) throw YoutubeDLException("Process ID already exists")
         // disable caching unless explicitly requested


### PR DESCRIPTION
yt-dlp pushes ffmpeg output to the error stream. In many cases when ffmpeg is used its pretty slow and takes up 90% of the download process and the end user has no idea what is happening because there is no new output information being shown.

Also a slight fix when killing child process. I also included killing the process itself always because killing child processes doesn't work as expected on older android versions.